### PR TITLE
Update v10 for latest changes.

### DIFF
--- a/v10.ksy
+++ b/v10.ksy
@@ -53,15 +53,15 @@ enums:
     46: com_constant
     47: com_splitter_word_2
     48: com_maker_word_2
-    49: com_punch_card
+    49: com_clz
     50: com_register_word_config
     51: com_ssd
     52: com_deleted_3
     53: com_ram_latency
-    54: com_pin_load
+    54: com_load_port
     55: com_delay_line_word
-    56: com_pin_store
-    57: com_file_loader
+    56: com_store_port
+    57: com_ctz
     58: com_cc_level_output
     59: com_level_gate
     60: com_level_input_1


### PR DESCRIPTION
- Add new Clz and Ctz component kinds. These reuse the IDs of the now-removed Punch Card and File Loader.

- Update RAM port component kinds to match the new internal names.